### PR TITLE
Personl home-pages location updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ To setup a basic homepage, run:
 curl -sSfl https://raw.githubusercontent.com/arghyadipchak/cmi-remote-access/main/homepage_basic.sh | bash
 ```
 
-You can then edit the `~/.www/index.html` as needed
+Email sysadm@cmi.ac.in, so that they can create <username> folder in /home/studentswww/
+Once created, you can then edit the `/home/studentswww/<username>/index.html` as needed
 
 To setup a homepage that redirects to another website, run:
 ```sh

--- a/homepage_basic.sh
+++ b/homepage_basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WWW="$HOME/.www"
+WWW="/home/studentswww/$USER"
 NAME=$(curl -s "https://www.cmi.ac.in/people/student-profile.php?id=$USER" | grep -oP '(?<=<div class="profile_name">)[^<]+')
 
 mkdir -p $WWW

--- a/homepage_forward.sh
+++ b/homepage_forward.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WWW="$HOME/.www"
+WWW="/home/studentswww/$USER"
 
 read -p "Enter url to forward to: " url </dev/tty
 


### PR DESCRIPTION
On 2025-02-10 22:31, Manoj Kummini wrote:
We have changed the location of the personal home-pages of students and
research scholars from .www to /home/studentswww/<your_userid>/ or
/home/rscholarswww/<your_userid>/ (as the case maybe), in order to limit
the exposure of the home areas. Hereafter, in order to make changes to
your pages, please ssh to access2.cmi.ac.in and cd to the appropriate
directory.

The files in .www have no value now. That directory is left untouched,
just as a back-up, in case some issue arose. You should edit the files
under /home/staffwww/<your_userid> only, and, that too, on
access2.cmi.ac.in.

If you find something amiss with your home-page or if you have any
questions, please write to <[sysadm@cmi.ac.in](mailto:sysadm@cmi.ac.in)>.